### PR TITLE
Various library improvements

### DIFF
--- a/sdformat_rs/build.rs
+++ b/sdformat_rs/build.rs
@@ -340,7 +340,7 @@ fn main() {
     }
 
     // For debug
-    fs::write("test_codegen.rs", contents.clone());
+    fs::write("test_codegen.rs", contents.clone()).unwrap();
 
     let out_dir = env::var_os("OUT_DIR").unwrap();
     let dest_path = Path::new(&out_dir).join("sdf.rs");

--- a/sdformat_rs/build.rs
+++ b/sdformat_rs/build.rs
@@ -160,7 +160,7 @@ impl SDFElement {
                 out += "\n";
             }
         }
-        out += "#[derive(Default, PartialEq, Debug, YaSerialize, YaDeserialize)]\n";
+        out += "#[derive(Default, PartialEq, Clone, Debug, YaSerialize, YaDeserialize)]\n";
         out += format!("#[yaserde(rename = \"{}\")]\n", self.properties.name).as_str();
         if self.top_level {
             out += format!("pub struct {}{} {{\n", prefix_type(prefix), self.typename()).as_str();
@@ -336,7 +336,7 @@ fn main() {
 
     let mut contents = "".to_string();
     for (file, model) in &hashmap {
-        if file == "plugin.sdf" || file == "frame.sdf" {
+        if file == "plugin.sdf" || file == "frame.sdf" || file == "geometry.sdf" {
             //Skip
             continue;
         }

--- a/sdformat_rs/build.rs
+++ b/sdformat_rs/build.rs
@@ -1,8 +1,8 @@
 use convert_case::{Case, Casing};
-use minidom::element;
-use std::collections::{hash_map, HashSet};
+
+use std::collections::HashSet;
 use std::error::Error;
-use std::fmt::format;
+
 use std::fs;
 use std::io::Cursor;
 use std::path::Path;
@@ -27,7 +27,7 @@ fn get_storage_type<'a>(type_str: &str) -> &'a str {
     if type_str == "vector3" {
         return "Vector3d";
     }
-    return "String";
+    "String"
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -43,9 +43,7 @@ impl RequiredStatus {
             RequiredStatus::Optional => {
                 format!("Option<{}>", type_str)
             }
-            RequiredStatus::One => {
-                format!("{}", type_str)
-            }
+            RequiredStatus::One => type_str.to_string(),
             RequiredStatus::Many => {
                 format!("Vec<{}>", type_str)
             }
@@ -154,8 +152,8 @@ impl SDFElement {
     fn code_gen(&self, prefix: &str, file_map: &HashMap<String, SDFElement>) -> String {
         let mut out = "".to_string();
         out += format!("// Generated from {}\n", self.source_file).as_str();
-        if (self.properties.description != "") {
-            for line in self.properties.description.split("\n") {
+        if !self.properties.description.is_empty() {
+            for line in self.properties.description.split('\n') {
                 out += &("/// ".to_string() + line);
                 out += "\n";
             }
@@ -179,7 +177,7 @@ impl SDFElement {
         let mut child_gen = "".to_string();
         let name = prefix.to_string().to_case(Case::Pascal) + self.properties.name.as_str();
         for child in &self.child_elems {
-            if child.properties.rtype == "" {
+            if child.properties.rtype.is_empty() {
                 // TODO(arjo): Handle includes
                 let prefix = prefix_type(&name);
                 child_gen += child.code_gen(prefix.as_str(), file_map).as_str();
@@ -222,8 +220,8 @@ impl SDFElement {
                 panic!("Unable to find element for file: {}", child.filename);
             }
         }
-        if self.properties.rtype.len() > 0 {
-            out += format!("#[yaserde(text)]\n   data: String\n").as_str(); //format!("data: {}", self.properties.rtype).as_str();
+        if !self.properties.rtype.is_empty() {
+            out += "#[yaserde(text)]\n   data: String\n".to_string().as_str(); //format!("data: {}", self.properties.rtype).as_str();
         }
         out += "}\n\n";
         out += child_gen.as_str();
@@ -280,51 +278,49 @@ fn parse_element(model: &mut SDFElement, element: &Element) {
     }
 
     for child in &element.children {
-        match child {
-            XMLNode::Element(el) => {
-                if el.name == "attribute" {
-                    parse_element(model, &el);
-                } else if el.name == "element" {
-                    if el.attributes.contains_key("ref") {
-                    } else {
-                        let mut elem = SDFElement::new();
-                        parse_element(&mut elem, &el);
-                        model.child_elems.push(elem);
-                    }
-                } else if el.name == "include" {
-                    let incl = SDFIncludes {
-                        filename: el.attributes.get("filename").unwrap().to_string(),
-                        required: RequiredStatus::from_str(el.attributes.get("required").unwrap()),
-                    };
-                    model.child_includes.push(incl);
-                } else if el.name == "description" {
-                    if let Some(desc) = el.get_text() {
-                        model.properties.description = desc.to_string();
-                    }
+        if let XMLNode::Element(el) = child {
+            if el.name == "attribute" {
+                parse_element(model, el);
+            } else if el.name == "element" {
+                if el.attributes.contains_key("ref") {
+                } else {
+                    let mut elem = SDFElement::new();
+                    parse_element(&mut elem, el);
+                    model.child_elems.push(elem);
+                }
+            } else if el.name == "include" {
+                let incl = SDFIncludes {
+                    filename: el.attributes.get("filename").unwrap().to_string(),
+                    required: RequiredStatus::from_str(el.attributes.get("required").unwrap()),
+                };
+                model.child_includes.push(incl);
+            } else if el.name == "description" {
+                if let Some(desc) = el.get_text() {
+                    model.properties.description = desc.to_string();
                 }
             }
-            _ => {}
         }
     }
 }
 
 fn read_all_specs() -> Result<HashMap<String, SDFElement>, String> {
     let mut res = HashMap::new();
-    for file in std::fs::read_dir("sdformat_spec/1.10").unwrap() {
-        if let Ok(dir_entry) = file {
-            if !dir_entry.metadata().unwrap().is_file() {
-                continue;
-            }
-            if let Some(sdf) = dir_entry.path().extension() {
-                if sdf == "sdf" {
-                    let spec = read_spec(dir_entry.path().to_str().unwrap()).unwrap();
-                    let mut model = SDFElement::new();
-                    parse_element(&mut model, &spec);
-                    model.top_level = true;
-                    model.set_source(dir_entry.file_name().to_str().unwrap());
-                    res.insert(dir_entry.file_name().to_str().unwrap().to_string(), model);
-                }
-            }
+    for dir_entry in std::fs::read_dir("sdformat_spec/1.10").unwrap().flatten() {
+        if !dir_entry.metadata().unwrap().is_file() {
+            continue;
+        }
+        if dir_entry
+            .path()
+            .extension()
+            .and_then(|e| e.to_str())
+            .eq(&Some("sdf"))
+        {
+            let spec = read_spec(dir_entry.path().to_str().unwrap()).unwrap();
+            let mut model = SDFElement::new();
+            parse_element(&mut model, &spec);
+            model.top_level = true;
+            model.set_source(dir_entry.file_name().to_str().unwrap());
+            res.insert(dir_entry.file_name().to_str().unwrap().to_string(), model);
         }
     }
 
@@ -334,7 +330,7 @@ fn read_all_specs() -> Result<HashMap<String, SDFElement>, String> {
 fn main() {
     let hashmap = read_all_specs().unwrap();
 
-    let mut contents = "".to_string();
+    let mut contents = String::new();
     for (file, model) in &hashmap {
         if file == "plugin.sdf" || file == "frame.sdf" || file == "geometry.sdf" {
             //Skip
@@ -348,6 +344,6 @@ fn main() {
 
     let out_dir = env::var_os("OUT_DIR").unwrap();
     let dest_path = Path::new(&out_dir).join("sdf.rs");
-    fs::write(&dest_path, contents).unwrap();
+    fs::write(dest_path, contents).unwrap();
     println!("cargo:rerun-if-changed=build.rs");
 }

--- a/sdformat_rs/src/lib.rs
+++ b/sdformat_rs/src/lib.rs
@@ -13,16 +13,46 @@ use yaserde_derive::{YaDeserialize, YaSerialize};
 include!(concat!(env!("OUT_DIR"), "/sdf.rs"));
 
 // Manually declare plugin
-#[derive(Default, PartialEq, Debug, YaSerialize, YaDeserialize)]
+#[derive(Default, PartialEq, Clone, Debug, YaSerialize, YaDeserialize)]
 #[yaserde(rename = "plugin")]
 pub struct SdfPlugin {}
 
 // Frame is another wierdo. For some reason it refuses to serialize/deserialize automatically
 // Hence the manual definition
 // Todo(arjo): Actually implement Frame.
-#[derive(Default, PartialEq, Debug, YaSerialize, YaDeserialize)]
+#[derive(Default, PartialEq, Clone, Debug, YaSerialize, YaDeserialize)]
 #[yaserde(rename = "frame")]
 pub struct SdfFrame {}
+
+// Geometry should really be an enum rather than a list of Options, redefine it here
+/// The shape of the visual or collision object.
+#[derive(Default, PartialEq, Clone, Debug, YaSerialize, YaDeserialize)]
+#[yaserde(rename = "geometry")]
+pub enum SdfGeometry {
+    #[yaserde(child, rename = "empty")]
+    #[default]
+    Empty,
+    #[yaserde(child, rename = "box")]
+    r#Box(SdfBoxShape),
+    #[yaserde(child, rename = "capsule")]
+    Capsule(SdfCapsuleShape),
+    #[yaserde(child, rename = "cylinder")]
+    Cylinder(SdfCylinderShape),
+    #[yaserde(child, rename = "ellipsoid")]
+    Ellipsoid(SdfEllipsoidShape),
+    #[yaserde(child, rename = "heightmap")]
+    Heightmap(SdfHeightmapShape),
+    #[yaserde(child, rename = "image")]
+    Image(SdfImageShape),
+    #[yaserde(child, rename = "mesh")]
+    Mesh(SdfMeshShape),
+    #[yaserde(child, rename = "plane")]
+    Plane(SdfPlaneShape),
+    #[yaserde(child, rename = "polyline")]
+    Polyline(SdfPolylineShape),
+    #[yaserde(child, rename = "sphere")]
+    Sphere(SdfSphereShape),
+}
 
 /// Simple implementation of pose
 pub struct Pose {

--- a/sdformat_rs/src/lib.rs
+++ b/sdformat_rs/src/lib.rs
@@ -123,6 +123,8 @@ impl SdfPose {
     }
 }
 
+pub use yaserde::de::from_str;
+
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct Vector3d(pub Vector3<f64>);
 

--- a/sdformat_rs/src/lib.rs
+++ b/sdformat_rs/src/lib.rs
@@ -149,7 +149,7 @@ impl YaDeserialize for Vector3d {
 }
 
 impl YaSerialize for Vector3d {
-    fn serialize<W: Write>(&self, writer: &mut yaserde::ser::Serializer<W>) -> Result<(), String> {
+    fn serialize<W: Write>(&self, _writer: &mut yaserde::ser::Serializer<W>) -> Result<(), String> {
         // serializer code
         Err("Not yet implemented".to_string())
     }
@@ -189,7 +189,7 @@ impl YaDeserialize for Vector3i {
 }
 
 impl YaSerialize for Vector3i {
-    fn serialize<W: Write>(&self, writer: &mut yaserde::ser::Serializer<W>) -> Result<(), String> {
+    fn serialize<W: Write>(&self, _writer: &mut yaserde::ser::Serializer<W>) -> Result<(), String> {
         // serializer code
         Err("Not yet implemented".to_string())
     }

--- a/sdformat_rs/tests/camera_test.rs
+++ b/sdformat_rs/tests/camera_test.rs
@@ -52,3 +52,12 @@ fn test_box_fragment() {
         );
     }
 }
+
+use sdformat_rs::SdfGeometry;
+#[test]
+fn test_geometry_enum() {
+    let test_syntax = "<geometry><box><size>0 0 1</size></box></geometry>";
+    let fr = from_str::<SdfGeometry>(test_syntax);
+    assert!(matches!(fr, Ok(_)));
+    assert!(matches!(fr.unwrap(), SdfGeometry::Box(_)));
+}

--- a/sdformat_rs/tests/camera_test.rs
+++ b/sdformat_rs/tests/camera_test.rs
@@ -45,7 +45,7 @@ fn test_box_fragment() {
 
     if let Ok(box_shape) = fr {
         assert!(
-            (box_shape.size.data - Vector3::<f64>::new(0.0, 0.0, 1.0))
+            (box_shape.size.0 - Vector3::<f64>::new(0.0, 0.0, 1.0))
                 .norm()
                 .abs()
                 < 0.000001


### PR DESCRIPTION
I played a bit with the library, some of these are cleanups some are quality of life improvements. Feel free to change anything, especially on the more opinionated cleanup side!

* General `cargo clippy`.
* Changed `SdfGeometry` to be an enum, added a unit test for it.
* A few cleanups through chaining functions instead of doing for loops / manual code, for example in `Vector3` types.
* Made `Vector3` types anonymous structs, only to reduce typing really.
* Reexport `yaserde::de::from_str`, otherwise library users need to depend on yaserde as well (I think).
* Derive `Clone` for all structs, necessary when moving is not an option.

It would be great if we could have a feature to denote whether types should be 32 or 64 bits, I know of libraries that do this but I'm not sure how to do it, for our use in `rmf_site` we have all 32 bit types and we need to cast every value manually, not a big issue but it could be avoided.

I also wanted to implement the serialization but didn't get to do it yet, it's not super necessary for now I guess.