### PR TITLE
Update nalgebra

### DIFF
--- a/sdformat_rs/Cargo.toml
+++ b/sdformat_rs/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 yaserde={version = "0.7.0"}
 yaserde_derive="0.7.0"
-nalgebra = "0.31.4"
+nalgebra = "0.32.2"
 
 [build-dependencies]
 minidom="0.15.0"


### PR DESCRIPTION
Pretty self-explanatory.

Apart from latest and greatest, in `rmf_site` there are two versions of `nalgebra` and converging to one will improve compile times:

```
nalgebra v0.31.4
└── sdformat_rs v0.1.0 (/usr/local/google/home/lucadv/sdf_rust_experimental/sdformat_rs) (*)

nalgebra v0.32.2 (*)
```