### PR TITLE
Add serialization / deserialization for arbitrary plugin trees

### DIFF
--- a/sdformat_rs/Cargo.lock
+++ b/sdformat_rs/Cargo.lock
@@ -24,12 +24,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17febce684fd15d89027105661fec94afb475cb995fbc59d2865198446ba2eea"
 
 [[package]]
-name = "bytes"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -72,25 +66,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "memchr"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
-
-[[package]]
-name = "minidom"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e9ce45d459e358790a285e7609ff5ae4cfab88b75f237e8838e62029dda397b"
-dependencies = [
- "rxml",
-]
-
-[[package]]
 name = "nalgebra"
-version = "0.31.4"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20bd243ab3dbb395b39ee730402d2e5405e448c75133ec49cc977762c4cba3d1"
+checksum = "307ed9b18cc2423f29e83f84fd23a8e73628727990181f18641a8b5dc2ab1caa"
 dependencies = [
  "approx",
  "matrixmultiply",
@@ -104,9 +83,9 @@ dependencies = [
 
 [[package]]
 name = "nalgebra-macros"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01fcc0b8149b4632adc89ac3b7b31a12fb6099a0317a4eb2ebff574ef7de7218"
+checksum = "91761aed67d03ad966ef783ae962ef9bbaca728d2dd7ceb7939ec110fffad998"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -159,12 +138,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
 
 [[package]]
-name = "pin-project-lite"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -189,25 +162,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
-name = "rxml"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a071866b8c681dc2cfffa77184adc32b57b0caad4e620b6292609703bceb804"
-dependencies = [
- "bytes",
- "pin-project-lite",
- "rxml_validation",
- "smartstring",
- "tokio",
-]
-
-[[package]]
-name = "rxml_validation"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53bc79743f9a66c2fb1f951cd83735f275d46bfe466259fbc5897bb60a0d00ee"
-
-[[package]]
 name = "safe_arch"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,7 +175,6 @@ name = "sdformat_rs"
 version = "0.1.0"
 dependencies = [
  "convert_case",
- "minidom",
  "nalgebra",
  "xmltree",
  "yaserde",
@@ -230,9 +183,9 @@ dependencies = [
 
 [[package]]
 name = "simba"
-version = "0.7.3"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3fd720c48c53cace224ae62bef1bbff363a70c68c4802a78b5cc6159618176"
+checksum = "061507c94fc6ab4ba1c9a0305018408e312e17c041eb63bef8aa726fa33aceae"
 dependencies = [
  "approx",
  "num-complex",
@@ -240,21 +193,6 @@ dependencies = [
  "paste",
  "wide",
 ]
-
-[[package]]
-name = "smartstring"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e714dff2b33f2321fdcd475b71cec79781a692d846f37f415fb395a1d2bcd48e"
-dependencies = [
- "static_assertions",
-]
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"
@@ -265,19 +203,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "tokio"
-version = "1.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03201d01c3c27a29c8a5cee5b55a93ddae1ccf6f08f65365c2c918f8c1b76f64"
-dependencies = [
- "autocfg",
- "bytes",
- "memchr",
- "pin-project-lite",
- "windows-sys",
 ]
 
 [[package]]
@@ -307,72 +232,6 @@ dependencies = [
  "bytemuck",
  "safe_arch",
 ]
-
-[[package]]
-name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "xml-rs"

--- a/sdformat_rs/Cargo.toml
+++ b/sdformat_rs/Cargo.toml
@@ -11,7 +11,6 @@ yaserde_derive="0.7.0"
 nalgebra = "0.32.2"
 
 [build-dependencies]
-minidom="0.15.0"
 xmltree = "0.10"
 convert_case = "0.6.0"
 

--- a/sdformat_rs/build.rs
+++ b/sdformat_rs/build.rs
@@ -221,7 +221,7 @@ impl SDFElement {
             }
         }
         if !self.properties.rtype.is_empty() {
-            out += "#[yaserde(text)]\n   data: String\n".to_string().as_str(); //format!("data: {}", self.properties.rtype).as_str();
+            out += "  #[yaserde(text)]\n   pub data: String\n".to_string().as_str(); //format!("data: {}", self.properties.rtype).as_str();
         }
         out += "}\n\n";
         out += child_gen.as_str();

--- a/sdformat_rs/build.rs
+++ b/sdformat_rs/build.rs
@@ -53,7 +53,7 @@ impl RequiredStatus {
     fn from_str(required: &str) -> RequiredStatus {
         if required == "true" || required == "1" {
             return RequiredStatus::One;
-        } else if required == "*" {
+        } else if required == "*" || required == "+" {
             return RequiredStatus::Many;
         }
         RequiredStatus::Optional

--- a/sdformat_rs/build.rs
+++ b/sdformat_rs/build.rs
@@ -221,9 +221,7 @@ impl SDFElement {
             }
         }
         if !self.properties.rtype.is_empty() {
-            out += "  #[yaserde(text)]\n   pub data: String\n"
-                .to_string()
-                .as_str(); //format!("data: {}", self.properties.rtype).as_str();
+            out += "  #[yaserde(text)]\n   pub data: String\n";
         }
         out += "}\n\n";
         out += child_gen.as_str();

--- a/sdformat_rs/src/lib.rs
+++ b/sdformat_rs/src/lib.rs
@@ -305,6 +305,12 @@ pub use yaserde::de::from_str;
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct Vector3d(pub Vector3<f64>);
 
+impl Vector3d {
+    pub fn new(x: f64, y:f64, z:f64) -> Self {
+        Self(Vector3::new(x, y, z))
+    }
+}
+
 impl YaDeserialize for Vector3d {
     fn deserialize<R: Read>(reader: &mut yaserde::de::Deserializer<R>) -> Result<Self, String> {
         // deserializer code
@@ -354,6 +360,12 @@ impl YaSerialize for Vector3d {
 
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct Vector3i(pub Vector3<i64>);
+
+impl Vector3i {
+    pub fn new(x: i64, y:i64, z:i64) -> Self {
+        Self(Vector3::new(x, y, z))
+    }
+}
 
 impl YaDeserialize for Vector3i {
     fn deserialize<R: Read>(reader: &mut yaserde::de::Deserializer<R>) -> Result<Self, String> {

--- a/sdformat_rs/src/lib.rs
+++ b/sdformat_rs/src/lib.rs
@@ -64,7 +64,6 @@ pub struct ElementMap {
 pub struct SdfPlugin {
     pub name: String,
     pub filename: String,
-    //pub elements: HashMap<String, XmlElement>,
     pub elements: ElementMap,
 }
 

--- a/sdformat_rs/src/lib.rs
+++ b/sdformat_rs/src/lib.rs
@@ -92,8 +92,6 @@ impl ElementMap {
     }
 }
 
-pub struct ElementMapIterator {}
-
 fn parse_data(val: &str) -> ElementData {
     if val.is_empty() {
         ElementData::Empty
@@ -353,6 +351,24 @@ pub use yaserde::de::from_str;
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct Vector3d(pub Vector3<f64>);
 
+impl TryFrom<String> for Vector3d {
+    type Error = String;
+
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        let sz = s
+            .split_whitespace()
+            .map(|x| x.parse::<f64>())
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|_| "Unable to parse Vector3 into floats".to_string())?;
+
+        if sz.len() != 3 {
+            return Err("Expected 3 items in Vec3 field".to_string());
+        }
+
+        Ok(Vector3d::new(sz[0], sz[1], sz[2]))
+    }
+}
+
 impl Vector3d {
     pub fn new(x: f64, y: f64, z: f64) -> Self {
         Vector3d(Vector3::new(x, y, z))
@@ -364,17 +380,7 @@ impl YaDeserialize for Vector3d {
         // deserializer code
         reader.next_event()?;
         if let Ok(xml::reader::XmlEvent::Characters(v)) = reader.peek() {
-            let sz = v
-                .split_whitespace()
-                .map(|x| x.parse::<f64>())
-                .collect::<Result<Vec<_>, _>>()
-                .map_err(|_| "Unable to parse Vector3 into floats".to_string())?;
-
-            if sz.len() != 3 {
-                return Err("Expected 3 items in Vec3 field".to_string());
-            }
-
-            Ok(Vector3d(Vector3::new(sz[0], sz[1], sz[2])))
+            v.clone().try_into()
         } else {
             Err("String of elements not found while parsing Vec3".to_string())
         }
@@ -421,6 +427,24 @@ impl YaSerialize for Vector3d {
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct Vector3i(pub Vector3<i64>);
 
+impl TryFrom<String> for Vector3i {
+    type Error = String;
+
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        let sz = s
+            .split_whitespace()
+            .map(|x| x.parse::<i64>())
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|_| "Unable to parse Vector3 into ints".to_string())?;
+
+        if sz.len() != 3 {
+            return Err("Expected 3 items in Vec3 field".to_string());
+        }
+
+        Ok(Vector3i::new(sz[0], sz[1], sz[2]))
+    }
+}
+
 impl Vector3i {
     pub fn new(x: i64, y: i64, z: i64) -> Self {
         Self(Vector3::new(x, y, z))
@@ -432,17 +456,7 @@ impl YaDeserialize for Vector3i {
         // deserializer code
         reader.next_event()?;
         if let Ok(xml::reader::XmlEvent::Characters(v)) = reader.peek() {
-            let sz = v
-                .split_whitespace()
-                .map(|x| x.parse::<i64>())
-                .collect::<Result<Vec<_>, _>>()
-                .map_err(|_| "Unable to parse Vector3 into ints".to_string())?;
-
-            if sz.len() != 3 {
-                return Err("Expected 3 items in Vec3 field".to_string());
-            }
-
-            Ok(Vector3i(Vector3::new(sz[0], sz[1], sz[2])))
+            v.clone().try_into()
         } else {
             Err("String of elements not found while parsing Vec3".to_string())
         }

--- a/sdformat_rs/tests/camera_test.rs
+++ b/sdformat_rs/tests/camera_test.rs
@@ -1,4 +1,3 @@
-use nalgebra::Vector;
 use yaserde::de::from_str;
 
 use sdformat_rs::SdfCamera;
@@ -60,4 +59,40 @@ fn test_geometry_enum() {
     let fr = from_str::<SdfGeometry>(test_syntax);
     assert!(matches!(fr, Ok(_)));
     assert!(matches!(fr.unwrap(), SdfGeometry::Box(_)));
+}
+
+use sdformat_rs::{ElementData, SdfPlugin};
+#[test]
+fn test_plugin() {
+    let test_plugin_content = |fr: &SdfPlugin| {
+        assert_eq!(fr.name, "hello");
+        assert_eq!(fr.filename, "world.so");
+        assert_eq!(fr.elements.len(), 1);
+        let (box_elem_name, box_elem) = fr.elements.iter().next().unwrap();
+        assert_eq!(box_elem_name, "box");
+        assert_eq!(box_elem.attributes.len(), 1);
+        let (attr_name, attr_value) = box_elem.attributes.iter().next().unwrap();
+        assert_eq!(
+            (attr_name, attr_value),
+            (&"name".into(), &ElementData::String("boxy".into()))
+        );
+        match &box_elem.data {
+            ElementData::Nested(data) => {
+                assert_eq!(data.len(), 1);
+                let (size_name, size_elem) = data.iter().next().unwrap();
+                assert_eq!(size_name, "size");
+                assert_eq!(size_elem.data, ElementData::Integer(42));
+            }
+            _ => panic!("Expected nested element"),
+        }
+    };
+    let test_syntax = "<plugin name=\"hello\" filename=\"world.so\"><box name=\"boxy\"><size>42</size><!-- A comment --></box></plugin>";
+    let fr = from_str::<SdfPlugin>(test_syntax).unwrap();
+    test_plugin_content(&fr);
+    // Serialize back
+    let to = yaserde::ser::to_string(&fr);
+    // Deserialize again and check that it's OK
+    let fr = from_str::<SdfPlugin>(test_syntax).unwrap();
+    test_plugin_content(&fr);
+    assert!(to.is_ok());
 }

--- a/sdformat_rs/tests/camera_test.rs
+++ b/sdformat_rs/tests/camera_test.rs
@@ -72,16 +72,13 @@ fn test_plugin() {
         assert_eq!(&*box_elem.name, "box");
         assert_eq!(box_elem.attributes.len(), 1);
         let (attr_name, attr_value) = box_elem.attributes.iter().next().unwrap();
-        assert_eq!(
-            (attr_name, attr_value),
-            (&"name".into(), &ElementData::String("boxy".into()))
-        );
+        assert_eq!((attr_name, attr_value), (&"name".into(), &"boxy".into()));
         match &box_elem.data {
             ElementData::Nested(data) => {
                 assert_eq!(data.all().len(), 1);
                 let size_elem = data.all().iter().next().unwrap();
                 assert_eq!(&*size_elem.name, "size");
-                assert_eq!(size_elem.data, ElementData::Integer(42));
+                assert_eq!(size_elem.data.clone().try_into(), Ok(42));
             }
             _ => panic!("Expected nested element"),
         }


### PR DESCRIPTION
## New feature implementation

### Implemented feature

This PR implements serialization / deserialization for plugin elements.
Since a plugin element can contain arbitrary application dependent data, the solution is sadly to just perform minimum parsing on the actual events emitted by the xml reader and just expose to the user hashmaps of elements and attributes.

### Implementation description

I added a unit test with a round trip for a plugin serialization / deserialization to show that it works (at least for the semi-simple test case!).
I'm open to refactoring parts of the implementation, especially in the public API that was kinda hacked together