### PR TITLE
Add unit test to show failure in vector3d serialization

### DIFF
--- a/sdformat_rs/src/lib.rs
+++ b/sdformat_rs/src/lib.rs
@@ -128,6 +128,12 @@ pub use yaserde::de::from_str;
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct Vector3d(pub Vector3<f64>);
 
+impl Vector3d {
+    pub fn new(x: f64, y: f64, z: f64) -> Self {
+        Vector3d(Vector3::new(x, y, z))
+    }
+}
+
 impl YaDeserialize for Vector3d {
     fn deserialize<R: Read>(reader: &mut yaserde::de::Deserializer<R>) -> Result<Self, String> {
         // deserializer code

--- a/sdformat_rs/tests/camera_test.rs
+++ b/sdformat_rs/tests/camera_test.rs
@@ -61,3 +61,15 @@ fn test_geometry_enum() {
     assert!(matches!(fr, Ok(_)));
     assert!(matches!(fr.unwrap(), SdfGeometry::Box(_)));
 }
+
+use sdformat_rs::{SdfLight, Vector3d};
+#[test]
+fn test_light_direction_pose() {
+    let light = SdfLight {
+        direction: Vector3d::new(4.0, 5.0, 6.0),
+        ..Default::default()
+    };
+    let serialized = yaserde::ser::to_string(&light);
+    dbg!(&serialized);
+    panic!();
+}


### PR DESCRIPTION
## Bug

What's better than a bug report? A bug report with a unit test showing where the issue is.
It seems that serialization of fields of type `Vector3d` doesn't quite work as intended, specifically they are serialized as text and the tag itself is not included.

This PR adds a simple unit test to show the issue, a light with a single `direction` field and an explicit panic just to print out the result. I would expect the light to be serialized as:

```
<light>
  <direction>4 5 6</direction>
</light>
```

What actually happens is:

```
<light>4 5 6</light>
```

I fear that it might be an issue in `yaserde`, I tried bumping locally to 0.8.0 but it doesn't seem to help

### Fix applied

None, yet!