### PR TITLE
Add support for nested models to yaserde

### DIFF
--- a/sdformat_rs/src/lib.rs
+++ b/sdformat_rs/src/lib.rs
@@ -20,6 +20,14 @@ pub struct Boxed<T> {
     inner: Box<T>,
 }
 
+impl<T> From<T> for Boxed<T> {
+    fn from(t: T) -> Self {
+        Self {
+            inner: Box::new(t),
+        }
+    }
+}
+
 impl<T: PartialEq> PartialEq for Boxed<T> {
     fn eq(&self, rhs: &Self) -> bool {
         self.inner == rhs.inner

--- a/sdformat_rs/tests/camera_test.rs
+++ b/sdformat_rs/tests/camera_test.rs
@@ -102,3 +102,12 @@ fn test_light_direction_pose_serdeser() {
     let serialized = yaserde::ser::to_string(&fr.unwrap()).unwrap();
     assert_eq!(test_syntax.to_string(), serialized);
 }
+
+use sdformat_rs::SdfModel;
+#[test]
+fn test_nested_model() {
+    let test_syntax = "<?xml version=\"1.0\" encoding=\"utf-8\"?><model name=\"top\"><model name=\"nested\" /></model>";
+    let fr = from_str::<SdfModel>(test_syntax);
+    let serialized = yaserde::ser::to_string(&fr.unwrap()).unwrap();
+    assert_eq!(test_syntax.to_string(), serialized);
+}


### PR DESCRIPTION
## New feature implementation

### Implemented feature

Alternative to #9.
Achieve nested models without changing the whole underlying library.

### Implementation description

Implementation inspired by https://github.com/media-io/yaserde/issues/165#issuecomment-1810243674, basically we add a layer of indirection to make sure that nested models are sized.
Created a `Boxed<T>` generic struct that we can use for items that use `ref` as their type (which turns out are just nested items).
Also added a simple roundtrip test for nested models