### PR TITLE
Add mutating API to plugin get()

### DIFF
--- a/sdformat_rs/src/lib.rs
+++ b/sdformat_rs/src/lib.rs
@@ -169,6 +169,12 @@ impl ElementMap {
             .and_then(|idxs| self.elements.get(*idxs.iter().next()?))
     }
 
+    pub fn get_mut(&mut self, name: &str) -> Option<&mut XmlElement> {
+        self.indexes
+            .get(name)
+            .and_then(|idxs| self.elements.get_mut(*idxs.iter().next()?))
+    }
+
     pub fn get_all(&self, name: &str) -> Option<Vec<&XmlElement>> {
         self.indexes
             .get(name)

--- a/sdformat_rs/tests/camera_test.rs
+++ b/sdformat_rs/tests/camera_test.rs
@@ -92,6 +92,17 @@ fn test_plugin() {
     let fr = from_str::<SdfPlugin>(test_syntax).unwrap();
     test_plugin_content(&fr);
     assert!(to.is_ok());
+
+    // Test accessing and mutating API
+    let test_syntax = "<plugin name=\"hello\" filename=\"world.so\"><size>42</size></plugin>";
+    let mut plugin = from_str::<SdfPlugin>(test_syntax).unwrap();
+    let size = plugin.elements.get("size").unwrap();
+    assert_eq!(size.data, ElementData::String("42".to_string()));
+    let size = plugin.elements.get_mut("size").unwrap();
+    size.data = ElementData::String("hello".to_string());
+
+    let size = plugin.elements.get("size").unwrap();
+    assert_eq!(size.data, ElementData::String("hello".to_string()));
 }
 
 use sdformat_rs::SdfLight;


### PR DESCRIPTION
## New feature implementation

### Implemented feature

Add a `get_mut(name)` API to access plugin elements mutably, otherwise plugins are immutable and can't be updated.

### Implementation description

Also added a unit test to test both the `get()` and `get_mut()` APIs