### PR TITLE
Add API for get_all_mut

### DIFF
--- a/sdformat_rs/tests/camera_test.rs
+++ b/sdformat_rs/tests/camera_test.rs
@@ -103,6 +103,32 @@ fn test_plugin() {
 
     let size = plugin.elements.get("size").unwrap();
     assert_eq!(size.data, ElementData::String("hello".to_string()));
+    // test get_all
+    let test_syntax = "<plugin name=\"hello\" filename=\"world.so\"><box name=\"box1\"></box><box name=\"box2\"></box></plugin>";
+    let mut plugin = from_str::<SdfPlugin>(test_syntax).unwrap();
+    {
+        let mut boxes = plugin.elements.get_all("box").unwrap();
+        let box1 = boxes.next().unwrap();
+        assert_eq!(
+            box1.attributes.values().next(),
+            Some("box1".to_string()).as_ref()
+        );
+        let box2 = boxes.next().unwrap();
+        assert_eq!(
+            box2.attributes.values().next(),
+            Some("box2".to_string()).as_ref()
+        );
+    }
+    {
+        {
+            let mut boxes = plugin.elements.get_all_mut("box").unwrap();
+            let box1 = boxes.next().unwrap();
+            box1.attributes
+                .insert("hello".to_string(), "world".to_string());
+        }
+        let box1 = plugin.elements.get("box").unwrap();
+        assert_eq!(box1.attributes.get("hello"), Some(&"world".to_string()));
+    }
 }
 
 use sdformat_rs::SdfLight;

--- a/sdformat_rs/tests/camera_test.rs
+++ b/sdformat_rs/tests/camera_test.rs
@@ -103,32 +103,19 @@ fn test_plugin() {
 
     let size = plugin.elements.get("size").unwrap();
     assert_eq!(size.data, ElementData::String("hello".to_string()));
-    // test get_all
-    let test_syntax = "<plugin name=\"hello\" filename=\"world.so\"><box name=\"box1\"></box><box name=\"box2\"></box></plugin>";
+    // test for_each and for_each_mut
+    let test_syntax = "<plugin name=\"hello\" filename=\"world.so\"><box name=\"boxy\"></box><box name=\"boxy\"></box></plugin>";
     let mut plugin = from_str::<SdfPlugin>(test_syntax).unwrap();
-    {
-        let mut boxes = plugin.elements.get_all("box").unwrap();
-        let box1 = boxes.next().unwrap();
-        assert_eq!(
-            box1.attributes.values().next(),
-            Some("box1".to_string()).as_ref()
-        );
-        let box2 = boxes.next().unwrap();
-        assert_eq!(
-            box2.attributes.values().next(),
-            Some("box2".to_string()).as_ref()
-        );
-    }
-    {
-        {
-            let mut boxes = plugin.elements.get_all_mut("box").unwrap();
-            let box1 = boxes.next().unwrap();
-            box1.attributes
-                .insert("hello".to_string(), "world".to_string());
-        }
-        let box1 = plugin.elements.get("box").unwrap();
-        assert_eq!(box1.attributes.get("hello"), Some(&"world".to_string()));
-    }
+    plugin.elements.for_each("box", |elem| {
+        assert_eq!(elem.attributes.values().next(), Some(&"boxy".to_string()));
+    });
+    plugin.elements.for_each_mut("box", |elem| {
+        elem.attributes
+            .insert("hello".to_string(), "world".to_string());
+    });
+    plugin.elements.for_each("box", |elem| {
+        assert_eq!(elem.attributes.get("hello"), Some(&"world".to_string()));
+    });
 }
 
 use sdformat_rs::SdfLight;


### PR DESCRIPTION
## New feature implementation

### Implemented feature

This PR adds an API to `ElementMap` to get mutable references to all the elements that match a certain key.
I also changed `get_all` to return an iterator rather than a `Vec` to avoid an unnecessary heap allocation.

### Implementation description

Sadly having multiple mutable references is a tricky business in rust and I had to introduce one line of `unsafe` code that I could use another pair of eyes on.
I made sure to add unit tests (also for the previously undocumented immuable version `get_all`) to make sure everything works as intended.
It seems to work OK with the downstream application.

We should probably start to refactor `lib.rs` into different files soon